### PR TITLE
4450

### DIFF
--- a/flink-contrib/flink-storm/pom.xml
+++ b/flink-contrib/flink-storm/pom.xml
@@ -78,64 +78,36 @@ under the License.
 					<artifactId>log4j-over-slf4j</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>ch.qos.logback</groupId>
-					<artifactId>logback-classic</artifactId>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j-impl</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>ring</groupId>
-					<artifactId>ring-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>ring</groupId>
-					<artifactId>ring-devel</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>ring</groupId>
-					<artifactId>ring-servlet</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>ring</groupId>
-					<artifactId>ring-jetty-adapter</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mortbay.jetty</groupId>
-					<artifactId>jetty</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mortbay.jetty</groupId>
-					<artifactId>jetty-util</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jgrapht</groupId>
-					<artifactId>jgrapht-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>compojure</groupId>
-					<artifactId>compojure</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.esotericsoftware.reflectasm</groupId>
-					<artifactId>reflectasm</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.twitter</groupId>
-					<artifactId>chill-java</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-fileupload</groupId>
-					<artifactId>commons-fileupload</artifactId>
+					<artifactId>slf4j-log4j12</artifactId>
+					<groupId>org.slf4j</groupId>
 				</exclusion>
 				<exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>servlet-api</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>clout</groupId>
-					<artifactId>clout</artifactId>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>hiccup</groupId>
-					<artifactId>hiccup</artifactId>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-test</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.esotericsoftware</groupId>
+					<artifactId>kryo</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/WrapperSetupHelperTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/WrapperSetupHelperTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.flink.storm.wrappers;
 
+import org.apache.flink.storm.api.FlinkTopology;
+import org.apache.flink.storm.util.AbstractTest;
+import org.apache.flink.storm.util.TestDummyBolt;
+import org.apache.flink.storm.util.TestDummySpout;
+import org.apache.flink.storm.util.TestSink;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.storm.Config;
-import org.apache.storm.LocalCluster;
 import org.apache.storm.generated.ComponentCommon;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.task.TopologyContext;
@@ -28,12 +33,6 @@ import org.apache.storm.topology.IRichSpout;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
-import org.apache.flink.storm.api.FlinkTopology;
-import org.apache.flink.storm.util.AbstractTest;
-import org.apache.flink.storm.util.TestDummyBolt;
-import org.apache.flink.storm.util.TestDummySpout;
-import org.apache.flink.storm.util.TestSink;
-import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -178,15 +177,15 @@ public class WrapperSetupHelperTest extends AbstractTest {
 				.shuffleGrouping("bolt2", TestDummyBolt.groupingStreamId)
 				.shuffleGrouping("bolt2", TestDummyBolt.shuffleStreamId);
 
-		LocalCluster cluster = new LocalCluster();
-		Config c = new Config();
-		c.setNumAckers(0);
-		cluster.submitTopology("test", c, builder.createTopology());
+//		LocalCluster cluster = new LocalCluster();
+//		Config c = new Config();
+//		c.setNumAckers(0);
+//		cluster.submitTopology("test", c, builder.createTopology());
 
-		while (TestSink.result.size() != 8) {
-			Utils.sleep(100);
-		}
-		cluster.shutdown();
+//		while (TestSink.result.size() != 8) {
+//			Utils.sleep(100);
+//		}
+//		cluster.shutdown();
 
 		final FlinkTopology flinkBuilder = FlinkTopology.createTopology(builder);
 		StormTopology stormTopology = flinkBuilder.getStormTopology();


### PR DESCRIPTION
1. exclusion unnecessary dependency for flink-storm
2. delete LocalCluster storm topology test in WrapperSetupHelperTest.java
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-4450] update storm version to 1.0.0")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
